### PR TITLE
Impl Serialize for opd structs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "opd-parser"
 description = "Parser for the OPD point cloud animation format"
-version = "0.1.1"
+version = "0.2.0"
 edition = "2021"
 authors = [
     "Zhixing Zhang <zhixing.zhang@foresightmining.com>"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -82,7 +82,11 @@ pub struct OpdHeaderDirective {
     pub meta: OpdHeaderDirectiveMeta,
 
     #[serde(rename = "numCentroids")]
-    pub num_centroids: usize,
+    pub num_centroids: Option<usize>,
+
+    
+    #[serde(rename = "numPoints")]
+    pub num_points: Option<usize>,
 
     pub origin: OpdHeaderDirectiveOrigin,
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -89,6 +89,10 @@ pub struct OpdHeaderDirective {
     pub precision: usize,
     pub scale: Vec3,
     pub frames: Vec<FrameMeta>,
+
+    pub index: Option<bool>,
+    #[serde(rename = "subCentroids")]
+    pub sub_centroids: Option<bool>
 }
 
 #[derive(Deserialize, Debug, Serialize)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,8 +1,8 @@
 mod parser;
 
-use glam::Vec3;
+pub use glam::Vec3;
 pub use parser::parse;
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 
 pub struct OpdFile {
     pub header: OpdHeader,
@@ -10,7 +10,7 @@ pub struct OpdFile {
     pub frames: Frames,
 }
 
-#[derive(Deserialize, Debug)]
+#[derive(Deserialize, Debug, Serialize)]
 pub struct OpdHeader {
     pub version: String,
     #[serde(rename = "type")]
@@ -70,13 +70,13 @@ pub enum Frames {
     I64(Vec<Frame<i64>>),
 }
 
-#[derive(Deserialize, Debug)]
+#[derive(Deserialize, Debug, Serialize, Clone)]
 pub struct FrameMeta {
     pub time: f32,
     pub offset: usize,
 }
 
-#[derive(Deserialize, Debug)]
+#[derive(Deserialize, Debug, Serialize)]
 pub struct OpdHeaderDirective {
     pub version: String,
     pub meta: OpdHeaderDirectiveMeta,
@@ -91,7 +91,7 @@ pub struct OpdHeaderDirective {
     pub frames: Vec<FrameMeta>,
 }
 
-#[derive(Deserialize, Debug)]
+#[derive(Deserialize, Debug, Serialize)]
 pub struct OpdHeaderDirectiveOrigin {
     pub x: f32,
     pub y: f32,
@@ -107,7 +107,7 @@ impl From<OpdHeaderDirectiveOrigin> for Vec3 {
     }
 }
 
-#[derive(Deserialize, Debug)]
+#[derive(Deserialize, Debug, Serialize)]
 pub struct OpdHeaderDirectiveMeta {
     #[serde(rename = "projectId")]
     pub project_id: String,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,6 +13,7 @@ pub struct OpdFile {
 #[derive(Deserialize, Debug, Serialize)]
 pub struct OpdHeader {
     pub version: String,
+    pub compressed: Option<String>,
     #[serde(rename = "type")]
     pub ty: String,
     pub directive: OpdHeaderDirective,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -96,7 +96,10 @@ pub struct OpdHeaderDirective {
 
     pub index: Option<bool>,
     #[serde(rename = "subCentroids")]
-    pub sub_centroids: Option<bool>
+    pub sub_centroids: Option<bool>,
+
+    #[serde(rename = "lastFrameCorrected")]
+    pub last_frame_corrected: Option<bool>
 }
 
 #[derive(Deserialize, Debug, Serialize)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -85,7 +85,6 @@ pub struct OpdHeaderDirective {
     #[serde(rename = "numCentroids")]
     pub num_centroids: Option<usize>,
 
-    
     #[serde(rename = "numPoints")]
     pub num_points: Option<usize>,
 
@@ -100,7 +99,7 @@ pub struct OpdHeaderDirective {
     pub sub_centroids: Option<bool>,
 
     #[serde(rename = "lastFrameCorrected")]
-    pub last_frame_corrected: Option<bool>
+    pub last_frame_corrected: Option<bool>,
 }
 
 #[derive(Deserialize, Debug, Serialize)]

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -14,9 +14,9 @@ pub fn parse(input: &[u8]) -> IResult<&[u8], OpdFile> {
     let (input, json_header) = length_data(be_u32)(input)?;
     let header: crate::OpdHeader = serde_json::from_slice(json_header).unwrap();
 
-    let (mut input, centroids) = count(parse_centroid, header.directive.num_centroids)(input)?;
+    let (mut input, centroids) = count(parse_centroid, header.directive.num_centroids.unwrap())(input)?;
 
-    let _base_offset = header.directive.num_centroids * 4 * 4;
+    let _base_offset = header.directive.num_centroids.unwrap() * 4 * 4;
     let _frame_data_len = header.directive.precision * 3;
 
     let frames = match header.directive.precision {
@@ -63,7 +63,7 @@ pub fn parse_frame<'a, T>(
     number_parser: NumberParser<'a, T>,
 ) -> IResult<&'a [u8], Vec<Frame<T>>> {
     assert_eq!(header.directive.precision, std::mem::size_of::<T>());
-    let base_offset = header.directive.num_centroids * 4 * 4;
+    let base_offset = header.directive.num_centroids.unwrap() * 4 * 4;
 
     let mut frames = Vec::with_capacity(header.directive.frames.len());
     for frame in header.directive.frames.windows(2) {

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -14,7 +14,8 @@ pub fn parse(input: &[u8]) -> IResult<&[u8], OpdFile> {
     let (input, json_header) = length_data(be_u32)(input)?;
     let header: crate::OpdHeader = serde_json::from_slice(json_header).unwrap();
 
-    let (mut input, centroids) = count(parse_centroid, header.directive.num_centroids.unwrap())(input)?;
+    let (mut input, centroids) =
+        count(parse_centroid, header.directive.num_centroids.unwrap())(input)?;
 
     let _base_offset = header.directive.num_centroids.unwrap() * 4 * 4;
     let _frame_data_len = header.directive.precision * 3;


### PR DESCRIPTION
Derive the Serialize trait for opd structs so that the same data structure could be used for opd file serialization as well.