### PR TITLE
Switch header to use f64 instead of f32

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "opd-parser"
 description = "Parser for the OPD point cloud animation format"
-version = "0.3.0"
+version = "0.4.0"
 edition = "2021"
 authors = [
     "Zhixing Zhang <zhixing.zhang@foresightmining.com>"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -111,12 +111,12 @@ pub struct OpdHeaderDirective {
 
 #[derive(Deserialize, Debug, Serialize)]
 pub struct OpdHeaderDirectiveOrigin {
-    pub x: f32,
-    pub y: f32,
-    pub z: f32,
+    pub x: f64,
+    pub y: f64,
+    pub z: f64,
 }
 
-impl From<OpdHeaderDirectiveOrigin> for [f32; 3] {
+impl From<OpdHeaderDirectiveOrigin> for [f64; 3] {
     fn from(value: OpdHeaderDirectiveOrigin) -> Self {
         [value.x, value.y, value.z]
     }


### PR DESCRIPTION
Casting to f32 was causing some accuracy issues when trying to import sub centroids into OrePro:

![image](https://github.com/ForesightMiningSoftwareCorporation/opd_parser/assets/8202612/10c67a91-c18d-4988-960e-cb823ca55c8a)
