### PR TITLE
Add centroid volume flag to OPD header

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "opd-parser"
 description = "Parser for the OPD point cloud animation format"
-version = "0.4.0"
+version = "0.5.0"
 edition = "2021"
 authors = [
     "Zhixing Zhang <zhixing.zhang@foresightmining.com>"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -91,6 +91,8 @@ pub struct OpdHeaderDirective {
 
     #[serde(rename = "numCentroids")]
     pub num_centroids: Option<usize>,
+    #[serde(rename = "hasCentroidVolumes")]
+    pub has_centroid_volumes: Option<bool>,
 
     #[serde(rename = "numPoints")]
     pub num_points: Option<usize>,


### PR DESCRIPTION
To improve backwards compatibility with OrePro, an additional flag has been added to the OPD header to indicate whether a file contains the final point volumes for moved centroids. This is only used for movement files. 